### PR TITLE
fix(client): set the missing key prop to the fragment in Quote

### DIFF
--- a/client/src/Components/Quote.js
+++ b/client/src/Components/Quote.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import {
   Card,
@@ -139,12 +139,12 @@ export default ({
           {typeof content !== "undefined" &&
             content.split("\n").map((line, i) =>
               i > 0 ? (
-                <>
+                <Fragment key={`line-${i}`}>
                   <br />
-                  <span key={i}>{line}</span>
-                </>
+                  <span>{line}</span>
+                </Fragment>
               ) : (
-                <span key={i}>{line}</span>
+                <span key={`line-${i}`}>{line}</span>
               )
             )}
         </Typography>


### PR DESCRIPTION
This removes the warning we had in the console and help React to render correctly.